### PR TITLE
Fixes error with data type in Curl example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [Estuary documentation](https://docs.estuary.tech)
 
-This repo contains all the documentation for [estuary.tech](https://estuary.tech).
+This repo contains all the documentation for [estuary.tech](https://estuary.tech), along with the website build logic. If you're looking for the [estuary.tech](https://estuary.tech) homepage repo, head to [github.com/application-research/estuary-www](https://github.com/application-research/estuary-www).
 
 ## Run locally
 
@@ -9,6 +9,12 @@ This repo contains all the documentation for [estuary.tech](https://estuary.tech
     ```shell
     git clone https://github.com/application-research/estuary-docs.git
     cd estuary-docs
+    ```
+
+1. Install dependencies:
+
+    ```shell
+    npm install
     ```
 
 1. Start the local server:

--- a/pages/tutorial-uploading-your-first-file.tsx
+++ b/pages/tutorial-uploading-your-first-file.tsx
@@ -49,9 +49,9 @@ const code = `class Example extends React.Component {
 }`;
 
 const curl = `curl
- -X POST https://api.estuary.tech/content/add
- -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" \
- -H "Content-Type: multipart/form-data" \
+ -X POST https://api.estuary.tech/content/add \\ 
+ -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" \\ 
+ -H "Content-Type: multipart/form-data" \\ 
  -F "data=@PATH_TO_YOUR_FILE"`;
 
 function TutorialUploadingYourFirstFile(props) {

--- a/pages/tutorial-uploading-your-first-file.tsx
+++ b/pages/tutorial-uploading-your-first-file.tsx
@@ -50,10 +50,9 @@ const code = `class Example extends React.Component {
 
 const curl = `curl
  -X POST https://api.estuary.tech/content/add
- -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
- -H "Accept: application/json"
- -H "Content-Type: multipart/form-data"
- -F "text=PATH_TO_FILE;type=text/plain"`;
+ -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" \
+ -H "Content-Type: multipart/form-data" \
+ -F "data=@PATH_TO_YOUR_FILE"`;
 
 function TutorialUploadingYourFirstFile(props) {
   return (


### PR DESCRIPTION
There's a funky error/typo/boo-boo in the Curl example of the [Uploading your first file tutorial](https://docs.estuary.tech/tutorial-uploading-your-first-file). This PR changes the Curl request example to:

```javascript
const curl = `curl
 -X POST https://api.estuary.tech/content/add
 -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" \
 -H "Content-Type: multipart/form-data" \
 -F "data=@PATH_TO_YOUR_FILE"`;
```

Closes https://github.com/application-research/estuary/issues/88.