### PR TITLE
fix: use dynamic import to import swagger-ui-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "remarkable-react": "^1.4.3",
     "sass": "1.48.0",
     "styled-components": "^5.3.3",
-    "swagger-ui-react": "^4.6.1"
+    "swagger-ui-react": "^4.11.1"
   },
   "devDependencies": {
     "@types/react": "^17.0.32",

--- a/pages/swagger-ui-page.tsx
+++ b/pages/swagger-ui-page.tsx
@@ -1,9 +1,11 @@
-import SwaggerUI from "swagger-ui-react"
+import * as React from 'react';
+import dynamic from "next/dynamic";
 import "swagger-ui-react/swagger-ui.css"
 
-
 function PageSwaggerTest(props) {
+  const SwaggerUI = dynamic(import('swagger-ui-react'), {ssr: false})
   return (
+    // @ts-ignore
     <SwaggerUI url="static/swagger/v1_0_0/swagger.json" docExpansion="list" deepLinking={true} />
   );
 }


### PR DESCRIPTION
# Changes
There are a few implications on the use of webpack modules to support the introduction of ESM build fragments for SwaggerUI. This PR upgrades the swagger-ui-react and use dynamic import to run the swagger-ui-page.

# Related Issues
https://github.com/swagger-api/swagger-ui/issues/7970#issuecomment-1128983041

# Verification

## Before
In some cases where in the host doesn't have the latest webpack installed, this page can return an error related to ESM modules.
![image](https://user-images.githubusercontent.com/4479171/169100542-18e25b1a-01f1-4fea-ba72-5988159164b5.png)

## After
After adding the dynamic import, the swagger-ui-page now shows up as expected.
![image](https://user-images.githubusercontent.com/4479171/169100263-dcfe88b0-4d45-4c66-adbe-92327f959067.png)
