### PR TITLE
chore: fix incompatible render() return type on react-live component(s)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "styled-components": "^5.3.3",
     "swagger-ui-react": "^4.11.1"
   },
+  "resolutions": {
+    "@types/react": "17.0.2",
+    "@types/react-dom": "17.0.2"
+  },
   "devDependencies": {
     "@types/react": "^17.0.32",
     "typescript": "^4.4.4"


### PR DESCRIPTION
# Change

There's an issue with incompatibility return type of react-live components to react-node. This is preventing us from building the app successfully.

This change adds the `react` resolution to specify strict restrictions for dependencies of dependencies.

# Verification
https://react-live-fix.onrender.com/