### PR TITLE
add api copy update

### DIFF
--- a/documentation/tutorial-uploading-your-first-file.md
+++ b/documentation/tutorial-uploading-your-first-file.md
@@ -4,6 +4,8 @@ Once you have an API key, you can use the code shown to upload a file to the Fil
 
 - If your data's size is under **3.57 GB**, the Filecoin storage deals will not immediately execute after the upload. That means you have some time to upload more data if you would like.
 
+- The add api has an upper size limit of about **30 GB**, larger files will need to be broken up.
+
 - We pick 6 Filecoin miners for you, so you don't have to worry about knowing about any. If you are curious which Miners [https://estuary.tech](https://estuary.tech) works with, scroll to the bottom of the screen.
 
 - If any miner fails to store your deal, we find another.


### PR DESCRIPTION
<img width="541" alt="Screen Shot 2022-08-23 at 4 14 25 PM" src="https://user-images.githubusercontent.com/19626270/186282128-46469a91-97d3-4e11-85d3-b565368fad66.png">

added the second bullet in the image above, an explicit mention of the add api's  ~30 gb size limit. This is in the 'uploading your first file' tutorial. 