### PR TITLE
grammar fix on get-invite-key page

### DIFF
--- a/pages/get-invite-key.tsx
+++ b/pages/get-invite-key.tsx
@@ -50,7 +50,7 @@ function GetInviteKey(props) {
               https://estuary.tech
             </a>{' '}
             to make Filecoin storage deals? Please fill out this form! We'll get back to you either
-            over Twitter or e-mail if we think you have an meaningful public data set.
+            over Twitter or e-mail if we think you have a meaningful public data set.
           </p>
 
           <div className={styles.title} style={{ marginTop: 48 }}>


### PR DESCRIPTION
<img width="733" alt="Screen Shot 2022-08-30 at 4 29 53 PM" src="https://user-images.githubusercontent.com/19626270/187561298-e81d354c-b15c-4164-8403-36fdbcc3ebaf.png">

- in the image above, it was previously 'an meaningful dataset', changed to 'a meaningful dataset'.