### PR TITLE
updating to upload.estuary.tech

### DIFF
--- a/documentation/tutorial-uploading-your-first-file.md
+++ b/documentation/tutorial-uploading-your-first-file.md
@@ -15,7 +15,7 @@ Based on the size of the data you used for this step, the example to the right m
 You can also use fetch in this example if you want.
 
 ```
-fetch('https://api.estuary.tech/content/add', {
+fetch('https://upload.estuary.tech/content/add', {
   method: "POST",
   headers: {
     Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',

--- a/documentation/tutorial-working-with-collections.md
+++ b/documentation/tutorial-working-with-collections.md
@@ -25,15 +25,15 @@ We're specially interested in the **uuid** field here, which is the unique ident
 There are multiple ways to add data to a collection. Here we will explore two endpoints: **/collections/add-content** and **/content/add-ipfs**.
 
 #### /collections/add-content
-Let's add two CIDs **QmW3sbi25Veqkg3o9qCMkTuosSw6S8hSPzAEffwA1tCf5S** and **QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4** using this endpoint:
+Let's use this endpoint to add the CID: **bafkreifswhx6q3vkqmhkzeegtf5e7gfmiuemt42zmr7odwx3dih5pqvkza** 
 ```
-curl -X POST https://api.estuary.tech/collections/add-content -d '{ "contents": [], "cids": [QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4, QmW3sbi25Veqkg3o9qCMkTuosSw6S8hSPzAEffwA1tCf5S], "coluuid": "28d923b5-2561-43ee-8ab3-fb42088666f2" }' -H "Content-Type: application/json" -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
+curl -X POST https://api.estuary.tech/collections/add-content -d '{ "contents": [], "cids": ["bafkreifswhx6q3vkqmhkzeegtf5e7gfmiuemt42zmr7odwx3dih5pqvkza"], "coluuid": "28d923b5-2561-43ee-8ab3-fb42088666f2" }' -H "Content-Type: application/json" -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
 ```
 **Obs:** Notice we used the uuid of the collection we created earlier (**28d923b5-2561-43ee-8ab3-fb42088666f2**) to identify the collection we want to upload content to.
 
 We can also use **estuaryId**s to specify contents that are already uploaded to Estuary in order to include them in a collection. When a file gets uploaded to Estuary, it gets a corresponding **estuaryId**. Let's first add a file (**file1.txt**) to estuary using the **/content/add** endpoint in order to get its contentID:
 ```
-curl -X POST https://api.estuary.tech/content/add -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@/tmp/file1.txt"
+curl -X POST https://upload.estuary.tech/content/add -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@/tmp/file1.txt"
 
 {
   "cid": "bafkqadlumvzxi2lom4qgm2lmmufa",
@@ -55,45 +55,47 @@ curl -X POST https://api.estuary.tech/collections/add-content -d '{ "contents": 
 #### /content/add-ipfs
 We can also use the **/content/add-ipfs** endpoint to add CIDs to estuary and also put them in a collection at the same API call. Using this endpoint we must specify the content by CID (in the **root** field):
 ```
-curl -X POST https://api.estuary.tech/content/add-ipfs -d '{ "name": "file1.txt", "root": "QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4", "coluuid": "28d923b5-2561-43ee-8ab3-fb42088666f2", "collectionPath": "/dir1/file1.txt" }' -H "Content-Type: application/json" -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
+curl -X POST https://api.estuary.tech/content/add-ipfs -d '{ "filename": "file1.txt", "root": "QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4", "coluuid": "28d923b5-2561-43ee-8ab3-fb42088666f2", "dir": "/dir1/file1.txt" }' -H "Content-Type: application/json" -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
 ```
 
-Notice we also specified a new field **collectionPath**. In the next section we will explore another feature of collections: collection directory paths.
+Notice we also specified a new field **dir**. In the next section we will explore another feature of collections: collection directory paths.
 
 ### Collection directory paths
 Besides having several collections to organize data, users can also further organize content inside collections using directory paths. Directory paths are filesystem-like paths such as **/this/is/a/path/to/a/file**. To create a path, we just need to put a file inside it using the **collectionPath** field. Let's take the example used in the last section:
 ```
-curl -X POST https://api.estuary.tech/content/add-ipfs -d '{ "name": "file1.txt", "root": "QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4", "coluuid": "28d923b5-2561-43ee-8ab3-fb42088666f2", "collectionPath": "/dir1/file1.txt" }' -H "Content-Type: application/json" -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
+curl -X POST https://api.estuary.tech/content/add-ipfs -d '{ "filename": "file1.txt", "root": "QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4", "coluuid": "28d923b5-2561-43ee-8ab3-fb42088666f2", "dir": "/dir1/file1.txt" }' -H "Content-Type: application/json" -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
 ```
-Since the **collectionPath** for **file1.txt** is **/dir1/file1.txt**, the path **/dir1/** inside that collection gets created, and we can list only the contents of that path:
+Since the **dir** for **file1.txt** is **/dir1/file1.txt**, the path **/dir1/** inside that collection gets created, and we can list only the contents of that path:
 ```
-curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" "https://api.estuary.tech/collections/fs/list?col=28d923b5-2561-43ee-8ab3-fb42088666f2&dir=/dir1"
+curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" "https://api.estuary.tech/collections/content?coluuid=28d923b5-2561-43ee-8ab3-fb42088666f2&dir=/dir1"
 [
   {
     "name": "file1.txt",
-    "dir": false,
+    "type": "directory",
     "size": 20,
     "contId": 11,
+    "dir":"/dir1",
+    "coluuid":"28d923b5-2561-43ee-8ab3-fb42088666f2"
     "cid": "QmS8dypUY34t3UF7Xd98KhuxqQ8F45WckJCGkdhNnwgvM4"
   }
 ]
 ```
 
 ### Listing all the contents of a collections
-When a piece of content doesn't have a directory path in a collection, it is impossible to list it using the **/collections/fs/list** endpoint since that requires a **dir** to be specified and, even if it isn't, it defaults to the **/** path. In order to list all the contents of a collection, even the ones that don't have a directory path set, we can use **/collections/content/:collection-uuid**:
+In order to list all the contents of a collection, even the ones that don't have a directory path set, we can use **/collections/content?coluuid=YOUR_COLLECTION_ID**
 
 ```
 curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" https://api.estuary.tech/collections/content?coluuid=28d923b5-2561-43ee-8ab3-fb42088666f2
 ```
 
 ### Deleting a collection
-In case you want to delete a previously created collection, you can do so with the following curl:
+You can use the **/content/list** endpoint to list all of your collections. If you want to delete a previously created collection, you can do so with the following curl:
 
 ```
-curl -X DELETE  https://api.estuary.tech/collections/<uuid> -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
+curl -X DELETE  https://api.estuary.tech/collections/<coluuid> -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY"
 ```
 
-where the query parameter **uuid** is the uuid of the collection you are trying to delete.
+where the query parameter **coluuid** is the uuid of the collection you are trying to delete. 
 
 
 

--- a/pages/api-content-add-car.tsx
+++ b/pages/api-content-add-car.tsx
@@ -16,11 +16,8 @@ For more information about this API swagger specification, see [here](swagger-ui
 We will be adding more code examples and more details over time. Thanks for bearing with us and our team! If you have ideas, write us some [feedback](https://docs.estuary.tech/feedback).
 `;
 
-
-
-
 const key = `api-content-add-car`;
-const curl = `curl -X POST https://api.estuary.tech/content/add-car -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -T PATH_TO_FILE`;
+const curl = `curl -X POST https://upload.estuary.tech/content/add-car -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -T PATH_TO_FILE`;
 
 const code = `class Example extends React.Component {
  upload(e) {
@@ -31,7 +28,7 @@ const code = `class Example extends React.Component {
     // because we want to show progress. But you can use
     // fetch in this example if you like.
     const xhr = new XMLHttpRequest();
-    var url = "https://api.estuary.tech";
+    var url = "https://upload.estuary.tech";
     xhr.upload.onprogress = (e) => {
       this.setState({ 
         loaded: event.loaded, 
@@ -59,7 +56,7 @@ const code = `class Example extends React.Component {
       </React.Fragment>
     );
   }
-}`
+}`;
 
 function APIContentAddCAR(props) {
   return (
@@ -82,4 +79,3 @@ export async function getServerSideProps(context) {
 }
 
 export default APIContentAddCAR;
-

--- a/pages/api-content-add.tsx
+++ b/pages/api-content-add.tsx
@@ -10,14 +10,6 @@ Use this endpoint to upload data to the Estuary Node, one file at a time.
 
 For more of an explanation, read [this](https://docs.estuary.tech/tutorial-uploading-your-first-file).
 
-### ?coluid=UUID-OF-YOUR-COLLECTION
-
-Adding this query paramter will add the file to any collection.
-
-### ?dir=/path/to/thing
-
-Adding this query parameter will add the file to a specific path in the collection
-
 ### Swagger
 For more information about this API swagger specification, see [here](swagger-ui-page#/content/post_content_add)
 
@@ -49,7 +41,7 @@ const code = `class Example extends React.Component {
     
     xhr.open(
       "POST", 
-      "https://api.estuary.tech/content/add"
+      "https://upload.estuary.tech/content/add"
     );
     xhr.setRequestHeader(
       "Authorization", 
@@ -69,7 +61,7 @@ const code = `class Example extends React.Component {
   }
 }`;
 
-const curl = `curl -X POST https://api.estuary.tech/content/add?coluuid=UUID-OF-YOUR-COLLECTION&dir=/foo/bar -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@PATH_TO_FILE_BUT_REMEMBER_THE_@_SYMBOL_IS_REQUIRED"`;
+const curl = `curl -X POST https://upload.estuary.tech/content/add -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -H "Content-Type: multipart/form-data" -F "data=@PATH_TO_FILE_BUT_REMEMBER_THE_@_SYMBOL_IS_REQUIRED"`;
 
 function APIContentAdd(props) {
   return (

--- a/pages/tutorial-uploading-your-first-file.tsx
+++ b/pages/tutorial-uploading-your-first-file.tsx
@@ -28,7 +28,7 @@ const code = `class Example extends React.Component {
     
     xhr.open(
       "POST", 
-      "https://shuttle-4.estuary.tech/content/add"
+      "https://upload.estuary.tech/content/add"
     );
     xhr.setRequestHeader(
       "Authorization", 
@@ -49,7 +49,7 @@ const code = `class Example extends React.Component {
 }`;
 
 const curl = `curl
- -X POST https://shuttle-4.estuary.tech/content/add \\ 
+ -X POST https://upload.estuary.tech/content/add \\ 
  -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" \\ 
  -H "Content-Type: multipart/form-data" \\ 
  -F "data=@PATH_TO_YOUR_FILE"`;


### PR DESCRIPTION
Only changes for: `tutorial-uploading-your-first-file.md`, `api-content-add-car.tsx`, and `tutorial-uploading-your-first-file.tsx` was updating them to use **upload.estuary.tech/content/add** instead of **api.estuary.tech/content/add** endpoint.

**tutorial-working-with-collections.md**
- updated to use **upload.estuary.tech**
- updated an outdated use of the add-ipfs endpoint and the surrounding instructions (see image below)
- added mention of how to use the **/content/list** endpoint to list the collections you've made
<img width="776" alt="tutorial-working-with-collections-change" src="https://user-images.githubusercontent.com/19626270/189264363-6cb6b491-0fa7-4500-89bc-36ce7561b658.png">


**api-content-add**
- updated to use **upload.estuary.tech**
- updated to reflect that this endpoint can no longer be used to add content to collections (see image below)
<img width="1097" alt="Screen Shot 2022-09-08 at 8 13 09 PM" src="https://user-images.githubusercontent.com/19626270/189264539-15abd57c-4f11-4254-9593-d08c113c036a.png">
