### PR TITLE
update to "listing your files" tutorial and to /pinning/pins documentation

### DIFF
--- a/components/RichText.tsx
+++ b/components/RichText.tsx
@@ -7,7 +7,10 @@ import { Remarkable } from 'remarkable';
 import RemarkableReactRenderer from 'remarkable-react';
 
 export default function RichText(props) {
-  const md = new Remarkable();
+  const md = new Remarkable({
+    linkTarget: '_blank',
+  });
+
   const markdown = md.render(props.children);
 
   return (

--- a/documentation/tutorial-listing-your-files.md
+++ b/documentation/tutorial-listing-your-files.md
@@ -5,24 +5,36 @@ After you have [uploaded a file](https://docs.estuary.tech/tutorial-uploading-yo
 Once you do so, here is an example of the output:
 
 ```
-{
-  "id": 16,
-  "cid": "QmTMBh4bCQFgzr1fTCjVb5pRBUe7v9673HTLZWh77sUHUx",
-  "name": "nasa-space-settlements-a-design-study.pdf",
-  "userId": 3,
+ "42": {
+  "id": 36534620,
+  "updatedAt": "2022-09-06T22:21:08.039349Z",
+  "cid": "bafybeicgpnok4bl2rkf4ceojlb376henq6f6ufwqqvyyzmuo4xloxypuwm",
+  "name": "nature-6.mp4",
+  "userId": 243,
   "description": "",
-  "size": 30886087,
+  "size": 83073242,
+  "type": 0,
   "active": true,
   "offloaded": false,
   "replication": 6,
   "aggregatedIn": 0,
-  "aggregate": false
-}
+  "aggregate": false,
+  "pinning": false,
+  "pinMeta": "",
+  "replace": false,
+  "origins": "",
+  "failed": false,
+  "location": "SHUTTLE1f8fbb04-44c2-41a2-a8ac-d3057589dd93HANDLE",
+  "dagSplit": false,
+  "splitFrom": 0
+ },
 ```
 
-You can use the CID to retrieve the file immediately by using an IPFS Gateway.
+You can use the CID to retrieve the file immediately by using an IPFS Gateway. Here is an example:
 
-> [https://dweb.link/ipfs/QmTMBh4bCQFgzr1fTCjVb5pRBUe7v9673HTLZWh77sUHUx](https://dweb.link/ipfs/QmTMBh4bCQFgzr1fTCjVb5pRBUe7v9673HTLZWh77sUHUx)
+> [https://api.estuary.tech/gw/ipfs/bafybeicgpnok4bl2rkf4ceojlb376henq6f6ufwqqvyyzmuo4xloxypuwm](https://api.estuary.tech/gw/ipfs/bafybeicgpnok4bl2rkf4ceojlb376henq6f6ufwqqvyyzmuo4xloxypuwm)
+
+The general format for accessing your content by CID is as follows: **https://api.estuary.tech/gw/ipfs/YOUR_DESIRED_CID**
 
 ### You are done
 

--- a/pages/pinning-list.tsx
+++ b/pages/pinning-list.tsx
@@ -6,12 +6,14 @@ import App from '@components/App';
 
 const markdown = `# ➟ /pinning/pins
 
-## Overview
-Pinning is a method that allows you to instruct IPFS to store a specific object at a specific location – by default, your local node, though this can be changed if you utilise a third-party remote pinning service. This endpoint lists all of the pinned objects.
+This endpoint lists all contents, whether they are pinned (active), inactive, failed, etc. **Important:** This is different than the **/content/list** endpoint, which will only list pinned (active) contents.
 
 ## Useful for the following scenarios
 - Retrieve a list of pinned objects and show them on a dashboard or a user interface.
 - Validate or verify any pinned objects by retrieving the list and evaluating each.
+
+## Overview of Pinning
+Pinning is a method that allows you to instruct IPFS to store a specific object at a specific location – by default, your local node, though this can be changed if you utilise a third-party remote pinning service. This endpoint lists all of the pinned objects.
 
 ### Swagger
 For more information about this API swagger specification, see [here](swagger-ui-page#/pinning/get_pinning_pins)


### PR DESCRIPTION
**Global Change**: RichText processor was changed to default to having links open in new tab

**Listing files tutorial**
- updated the example output to more accurately reflect the real expected output
- changed the recommended IPFS gateway for accessing uploaded content 
<img width="599" alt="tutorial-listing-your-files-changes" src="https://user-images.githubusercontent.com/19626270/189266737-36656882-35b2-4087-9061-aa03b200cb29.png">

**/pinning/pins documentation:**
- added a description that explains the difference between /pinning/pins and /content/list
<img width="619" alt="pinning-list-changes" src="https://user-images.githubusercontent.com/19626270/189266732-b77af39d-41e4-46e1-8751-07ca5f09303b.png">
