### PR TITLE
Fix extra indentations on JS scripts

### DIFF
--- a/.github/workflows/gen-api-endpoints.yml
+++ b/.github/workflows/gen-api-endpoints.yml
@@ -8,16 +8,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - name: Build
       run: ./scripts/gen-and-update-pages.sh
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@main
+      uses: tj-actions/changed-files@v29.0.4
+      with:
+        files: ./pages/*
 
     - name: Add files
       uses: maxgfr/github-commit-push-file@main
+      if: steps.changed-files.outputs.any_changed == 'true'
       with:
         commit_name: 'docs: update API endpoints'
-      if: steps.changed-files.outputs.any_changed == 'true'

--- a/pages/api-content-by-cid.tsx
+++ b/pages/api-content-by-cid.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/by-cid/{cid}', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/by-cid/{cid}', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl =
   'curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" https://api.estuary.tech/content/by-cid/QmQTi9dkvZtHoWdiDT5LYPoe9G3yL9AzPTR9V2nPr8DAaN';

--- a/pages/api-content-deals.tsx
+++ b/pages/api-content-deals.tsx
@@ -20,26 +20,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/content/deals?limit=LIMIT&offset=OFFSET', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/content/deals?limit=LIMIT&offset=OFFSET', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl =
   'curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" https://api.estuary.tech/content/deals';

--- a/pages/api-content-stats.tsx
+++ b/pages/api-content-stats.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/content/stats', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/content/stats', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl =
   'curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" https://api.estuary.tech/content/stats';

--- a/pages/api-content-status-id.tsx
+++ b/pages/api-content-status-id.tsx
@@ -20,26 +20,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/content/status/{id}', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/content/status/{id}', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl =
   'curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" https://api.estuary.tech/content/status/12';

--- a/pages/api-public-metrics-deals-on-chain.tsx
+++ b/pages/api-public-metrics-deals-on-chain.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/metrics/deals-on-chain', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/metrics/deals-on-chain', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = 'curl -X GET https://api.estuary.tech/public/metrics/deals-on-chain';
 

--- a/pages/api-public-miners-deals.tsx
+++ b/pages/api-public-miners-deals.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/miners/deals/{miner}', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/miners/deals/{miner}', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = 'curl -X GET https://api.estuary.tech/public/miners/deals/f0135078';
 

--- a/pages/api-public-miners-failures.tsx
+++ b/pages/api-public-miners-failures.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/miners/failures/{miner}?miner=MINER', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/miners/failures/{miner}?miner=MINER', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = 'curl -X GET https://api.estuary.tech/public/miners/failures/f02387';
 

--- a/pages/api-public-miners-stats.tsx
+++ b/pages/api-public-miners-stats.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/miners/stats/{miner}', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/miners/stats/{miner}', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = 'curl -X GET https://api.estuary.tech/public/miners/stats/f0135078';
 

--- a/pages/api-public-miners.tsx
+++ b/pages/api-public-miners.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/miners', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/miners', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = 'curl -X GET https://api.estuary.tech/public/miners';
 

--- a/pages/api-public-stats.tsx
+++ b/pages/api-public-stats.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/public/stats', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/public/stats', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = 'curl -X GET https://api.estuary.tech/public/stats';
 

--- a/pages/collections-commit.tsx
+++ b/pages/collections-commit.tsx
@@ -21,26 +21,26 @@ const contents = `[]`;
 const cids = `[]`;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/collections/{coluuid}/commit', {
-                  method: 'POST',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/collections/{coluuid}/commit', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X POST https://api.estuary.tech/collections/{coluuid}/commit -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/pages/collections-list-content.tsx
+++ b/pages/collections-list-content.tsx
@@ -20,26 +20,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/collections/content?coluuid=COLUUID&dir=DIR', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/collections/content?coluuid=COLUUID&dir=DIR', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X GET https://api.estuary.tech/collections/content?coluuid=COLUUID&dir=DIR -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/pages/collections-list.tsx
+++ b/pages/collections-list.tsx
@@ -18,26 +18,26 @@ We will be adding more code examples and more details over time. Thanks for bear
 `;
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/collections/list', {
-                  method: 'GET',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/collections/list', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl =
   'curl -X GET -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" https://api.estuary.tech/collections/list';

--- a/pages/pinning-add.tsx
+++ b/pages/pinning-add.tsx
@@ -29,26 +29,26 @@ const key = 'pinning-add';
 const route = 'https://api.estuary.tech/pinning/pins';
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/pinning/pins', {
-                  method: 'POST',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/pinning/pins', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X POST https://api.estuary.tech/pinning/pins -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/pages/pinning-get.tsx
+++ b/pages/pinning-get.tsx
@@ -24,26 +24,26 @@ const key = 'pinning-get-by-id';
 const route = 'https://api.estuary.tech/pinning/pins/:id';
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
-                  method: 'DELETE',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
+      method: 'DELETE',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X DELETE https://api.estuary.tech/pinning/pins/{pinid} -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/pages/pinning-list.tsx
+++ b/pages/pinning-list.tsx
@@ -29,26 +29,26 @@ const key = 'pinning-list';
 const route = 'https://api.estuary.tech/pinning/pins';
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/pinning/pins', {
-                  method: 'POST',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/pinning/pins', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X POST https://api.estuary.tech/pinning/pins -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/pages/pinning-remove.tsx
+++ b/pages/pinning-remove.tsx
@@ -25,26 +25,26 @@ const key = 'pinning-remove';
 const route = 'https://api.estuary.tech/pinning/pins/:id';
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
-                  method: 'DELETE',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
+      method: 'DELETE',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X DELETE https://api.estuary.tech/pinning/pins/{pinid} -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/pages/pinning-replace.tsx
+++ b/pages/pinning-replace.tsx
@@ -25,26 +25,26 @@ const key = 'pinning-replace';
 const route = 'https://api.estuary.tech/pinning/pins/:id';
 
 const code = `class Example extends React.Component {
-              componentDidMount() {
-                fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
-                  method: 'DELETE',
-                  headers: {
-                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-                  },
-                  
-                })
-                  .then(data => {
-                    return data.json();
-                  })
-                  .then(data => {
-                    this.setState({ ...data });
-                  });
-              }
+  componentDidMount() {
+    fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
+      method: 'DELETE',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
 
-              render() {
-                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-              }
-            }`;
+    })
+      .then(data => {
+        return data.json();
+      })
+      .then(data => {
+        this.setState({ ...data });
+      });
+  }
+
+  render() {
+    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+  }
+}`;
 
 const curl = `curl -X DELETE https://api.estuary.tech/pinning/pins/{pinid} -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
 

--- a/scripts/gen-js-commands.py
+++ b/scripts/gen-js-commands.py
@@ -8,6 +8,7 @@ import json
 import urllib.request
 from urllib.parse import urlencode
 from pathlib import Path
+from textwrap import dedent
 
 BASE_API_URL = 'https://api.estuary.tech'
 SWAGGER_FILE_URL = "https://raw.githubusercontent.com/application-research/estuary/master/docs/swagger.json"
@@ -115,4 +116,4 @@ if __name__ == '__main__':
             }}
         '''
         with open('code-snippets/'+endpoint.replace('/', '')+'/js.txt', 'w+') as txt_file:
-            txt_file.write(js_string)
+            txt_file.write(dedent(js_string))

--- a/scripts/update-commands-on-pages.py
+++ b/scripts/update-commands-on-pages.py
@@ -1,21 +1,36 @@
 import os
 import sys
 import re
+from textwrap import dedent
 
 
-
-def fix_page(filename, page_text):
+def get_endpoint(page_text):
     # get everything after 'const markdown = `# ➟ ' in that line
     pattern = re.compile('const markdown = `# ➟ (.*)\n')
+    endpoint = ""
     try:
         old_endpoint = pattern.search(page_text).groups()[0]
-        endpoint = re.sub(r"/:([a-z]*)", r"/{\1}", old_endpoint) # fix :miner to {miner}
+        # fix :miner to {miner}
+        endpoint = re.sub(r"/:([a-z]*)", r"/{\1}", old_endpoint)
     except AttributeError:
-        return # page already fixed (?)
+        pass
 
-    if endpoint == '` + endpoint + `':
-        return # page already fixed
+    # endpoint is in new format, get it from the 'const endpoint' line
+    if endpoint != '` + endpoint + `':
+        return endpoint, False
 
+    pattern = re.compile("const endpoint = '(.*)';\n")
+    try:
+        endpoint = pattern.search(page_text).groups()[0]
+    except AttributeError:
+        print('error: could not find either endpoint')
+        return ""
+
+    return endpoint, True
+
+
+
+def fix_endpoint(endpoint, page_text):
     # set this as endpoint var 'const endpoint = my-endpoint;
     # replace 'const markdown' for
     # const endpoint = my-endpoint;
@@ -25,11 +40,11 @@ def fix_page(filename, page_text):
 
     # replace everything after 'const markdown = `# ➟ ' in that line by ` + endpoint +
     page_text = re.sub('const markdown = `# ➟ (.*)\n', f'const markdown = `# ➟ ` + endpoint + `\n', page_text)
+    return page_text
 
 
+def fix_curl(endpoint, page_text):
     curl_filename = './code-snippets/'+endpoint.replace('/', '').split('?')[0]+'/curl.txt'
-    js_filename = './code-snippets/'+endpoint.replace('/', '').split('?')[0]+'/js.txt'
-
     # set curl to contents of curl_filename
     try:
         with open(curl_filename, 'r') as curl_file:
@@ -37,6 +52,11 @@ def fix_page(filename, page_text):
         page_text = re.sub('const curl = `(.*)`', f"const curl = `{curl_str}`", page_text)
     except FileNotFoundError:
         print(f'could not find {curl_filename}, skipping')
+    return page_text
+
+
+def fix_js(endpoint, page_text):
+    js_filename = './code-snippets/'+endpoint.replace('/', '').split('?')[0]+'/js.txt'
 
     # if XMLHttpRequest is in the file, replace this part in code: 'url+"` + endpoint + `"'
     pattern = re.compile('XMLHttpRequest')
@@ -46,7 +66,7 @@ def fix_page(filename, page_text):
     # if XMLHttpRequest is not in the file, set code to contents of js_filename
         try:
             with open(js_filename, 'r') as js_file:
-                js_str = js_file.read().strip()
+                js_str = dedent(js_file.read().strip())
             page_text = re.sub('const code = `(.*)}`;', f"const code = `{js_str}`;", page_text, flags=re.S)
         except FileNotFoundError:
             print(f'could not find {js_filename}, skipping')
@@ -54,20 +74,32 @@ def fix_page(filename, page_text):
     return page_text
 
 
-for filename in os.listdir('./pages'):
-    if not filename.endswith(".tsx"):
-        continue
+if __name__ == '__main__':
+    for filename in os.listdir('./pages'):
+        if not filename.endswith(".tsx"):
+            continue
 
-    # open page file
-    with open('./pages/'+filename, 'r') as page:
-        fixed_page = fix_page(filename, page.read())
+        # open page file
+        with open('./pages/'+filename, 'r') as page:
+            page_text = page.read()
+            endpoint, is_new_format = get_endpoint(page_text)
+            if endpoint == '':
+                print(f'Skipping {filename}, wrong format')
+                continue
+            print(f'endpoint: {endpoint}; is_new_format: {is_new_format}')
+            if not is_new_format:
+                page_text = fix_endpoint(endpoint, page_text)
+            page_text = fix_curl(endpoint, page_text)
+            page_text = fix_js(endpoint, page_text)
 
-    if fixed_page == None:
-        continue
+            if not is_new_format:
+                page_text = fix_endpoint(endpoint, page_text)
+            page_text = fix_curl(endpoint, page_text)
+            page_text = fix_js(endpoint, page_text)
 
-    if len(sys.argv) == 2 and sys.argv[1] == "print":
-        print(fixed_page)
-    else:
-        # write and truncate to new file
-        with open('./pages/'+filename, 'w+') as page:
-            page.write(fixed_page)
+        if len(sys.argv) == 2 and sys.argv[1] == "print":
+            print(page_text)
+        else:
+            # write and truncate to new file
+            with open('./pages/'+filename, 'w+') as page:
+                page.write(page_text)


### PR DESCRIPTION
This PR fixes the extra indentations on JS scripts generated by #48. It also makes the autogen scripts more clean and useful. Now you can run them multiple times on the same file without worrying about it making weird changes (I think the fancy word for this is idempotent)

Fixes #49 