### PR TITLE
fixed add-ipfs documentation

### DIFF
--- a/pages/api-content-add-ipfs.tsx
+++ b/pages/api-content-add-ipfs.tsx
@@ -5,7 +5,10 @@ import * as React from 'react';
 import App from '@components/App';
 
 const endpoint = '/content/add-ipfs';
-const markdown = `# ➟ ` + endpoint + `
+const markdown =
+  `# ➟ ` +
+  endpoint +
+  `
 
 Use this endpoint to take an existing IPFS CID, and make storage deals for it.
 
@@ -32,7 +35,7 @@ const code = `class Example extends React.Component {
                     Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
                   },
                   body: JSON.stringify({
-body: 'BODY',
+root: 'YOUR_CID_HERE',
 })
                 })
                   .then(data => {
@@ -48,7 +51,7 @@ body: 'BODY',
               }
             }`;
 
-const curl = `curl -X POST https://api.estuary.tech/content/add-ipfs -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -d '{"body": "BODY"}'`;
+const curl = `curl -X POST https://api.estuary.tech/content/add-ipfs -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -d '{"root": "REPLACE_ME_WITH_CID"}'`;
 
 function APIContentAddIPFS(props) {
   return (

--- a/pages/api-public-miners-ask.tsx
+++ b/pages/api-public-miners-ask.tsx
@@ -19,7 +19,13 @@ We will be adding more code examples and more details over time. Thanks for bear
 
 const code = `class Example extends React.Component {
   componentDidMount() {
-    fetch('https://api.estuary.tech/public/miners/storage/query/f0135078')
+    fetch('https://api.estuary.tech/public/miners/storage/query/{miner}', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+      },
+
+    })
       .then(data => {
         return data.json();
       })

--- a/pages/api-public-miners-failures.tsx
+++ b/pages/api-public-miners-failures.tsx
@@ -19,7 +19,7 @@ We will be adding more code examples and more details over time. Thanks for bear
 
 const code = `class Example extends React.Component {
   componentDidMount() {
-    fetch('https://api.estuary.tech/public/miners/failures/{miner}?miner=MINER', {
+    fetch('https://api.estuary.tech/public/miners/failures/{miner}', {
       method: 'GET',
       headers: {
         Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',


### PR DESCRIPTION
changed the `body` key in the request data to the appropriate `root` key. Users will no longer get errors using this example.