### PR TITLE
fix payload on pinning-add and pinning-replace

### DIFF
--- a/pages/pinning-add.tsx
+++ b/pages/pinning-add.tsx
@@ -30,28 +30,30 @@ const key = 'pinning-add';
 const route = 'https://api.estuary.tech/pinning/pins';
 
 const code = `class Example extends React.Component {
-  componentDidMount() {
-    fetch('https://api.estuary.tech/pinning/pins', {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-      },
+              componentDidMount() {
+                fetch('https://api.estuary.tech/pinning/pins', {
+                  method: 'POST',
+                  headers: {
+                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+                  },
+                  body: JSON.stringify({
+pin: 'PIN',
+})
+                })
+                  .then(data => {
+                    return data.json();
+                  })
+                  .then(data => {
+                    this.setState({ ...data });
+                  });
+              }
 
-    })
-      .then(data => {
-        return data.json();
-      })
-      .then(data => {
-        this.setState({ ...data });
-      });
-  }
+              render() {
+                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+              }
+            }`;
 
-  render() {
-    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-  }
-}`;
-
-const curl = `curl -X POST https://api.estuary.tech/pinning/pins -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
+const curl = `curl -X POST https://api.estuary.tech/pinning/pins -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -d '{"pin": "PIN"}'`;
 
 function PinningAdd(props) {
   return (

--- a/pages/pinning-replace.tsx
+++ b/pages/pinning-replace.tsx
@@ -26,28 +26,33 @@ const key = 'pinning-replace';
 const route = 'https://api.estuary.tech/pinning/pins/:id';
 
 const code = `class Example extends React.Component {
-  componentDidMount() {
-    fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
-      method: 'POST',
-      headers: {
-        Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
-      },
+              componentDidMount() {
+                fetch('https://api.estuary.tech/pinning/pins/{pinid}', {
+                  method: 'POST',
+                  headers: {
+                    Authorization: 'Bearer REPLACE_ME_WITH_API_KEY',
+                  },
+                  body: JSON.stringify({
+cid: 'CID',
+, name: 'NAME',
+, origins: 'ORIGINS',
+, meta: 'META',
+})
+                })
+                  .then(data => {
+                    return data.json();
+                  })
+                  .then(data => {
+                    this.setState({ ...data });
+                  });
+              }
 
-    })
-      .then(data => {
-        return data.json();
-      })
-      .then(data => {
-        this.setState({ ...data });
-      });
-  }
+              render() {
+                return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
+              }
+            }`;
 
-  render() {
-    return <pre>{JSON.stringify(this.state, null, 1)}</pre>;
-  }
-}`;
-
-const curl = `curl -X POST https://api.estuary.tech/pinning/pins/{pinid} -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json"`;
+const curl = `curl -X POST https://api.estuary.tech/pinning/pins/{pinid} -H "Authorization: Bearer REPLACE_ME_WITH_API_KEY" -H "Accept: application/json" -d '{"cid": "CID", "name": "NAME", "origins": "ORIGINS", "meta": "META"}'`;
 
 function PinningReplace(props) {
   return (


### PR DESCRIPTION
warning: this conflicts with the api update workflow, so I'm skipping the CI on this. If we merge other PRs before estuary master gets updated with the up-to-date swagger.json file, we will go back to having outdated docs